### PR TITLE
Add output on `running` state with time and energy up to that point

### DIFF
--- a/power-monitor/power-monitor.js
+++ b/power-monitor/power-monitor.js
@@ -104,6 +104,16 @@
                 if (above) {
                     node.energy = node.energy + energy;
                     node.count = node.count + 1;
+                    node.send([
+                        { "payload": {
+                            "name": node.name,
+                            "event": "pre_start",
+                            "time": Math.round(time - node.start),
+                            "energy": kwh(node.energy),
+                            "energy_delta": kwh(energy)    
+                        }},
+                        null
+                    ]);
                     if (node.count >= node.startafter) node.state = 2;
                 } else {
                     node.state = 0;

--- a/power-monitor/power-monitor.js
+++ b/power-monitor/power-monitor.js
@@ -128,9 +128,10 @@
                     node.send([
                         { "payload": {
                             "name": node.name,
-                            "event": "running",
+                            "event": "start",
                             "time": Math.round(time - node.start),
-                            "energy": kwh(node.energy)
+                            "energy": kwh(node.energy),
+                            "energy_delta": kwh(energy)    
                         }},
                         null
                     ]);

--- a/power-monitor/power-monitor.js
+++ b/power-monitor/power-monitor.js
@@ -125,6 +125,15 @@
             if (3 === node.state) {
                 if (above) {
                     node.energy = node.energy + energy;
+                    node.send([
+                        { "payload": {
+                            "name": node.name,
+                            "event": "running",
+                            "time": Math.round(time - node.start),
+                            "energy": kwh(node.energy)
+                        }},
+                        null
+                    ]);
                 } else {
                     node.count = 0;
                     node.state = 4;

--- a/power-monitor/power-monitor.js
+++ b/power-monitor/power-monitor.js
@@ -128,7 +128,7 @@
                     node.send([
                         { "payload": {
                             "name": node.name,
-                            "event": "start",
+                            "event": "running",
                             "time": Math.round(time - node.start),
                             "energy": kwh(node.energy),
                             "energy_delta": kwh(energy)    

--- a/readme.md
+++ b/readme.md
@@ -49,15 +49,18 @@ The node will trigger events based on the start and stop conditions with additio
 ### Output
 
 The output will be a JSON object with the appliance name and the event type. 
-In case the event is a `running` event, it will also report the **current** running time (in seconds) and the **current** energy consumption of the cycle (in kWh) since it started, as well as the `energy_delta` in kWh since last update. 
-In case the event is a `stop` event, it will also report the **total** time (in seconds) and the **total** energy consumption of the cycle (in kWh). Examples:
+- In case the event is a `pre_start` or `running` event, it will also report the **current** running time (in seconds) and the **current** energy consumption of the cycle (in kWh) since it started, as well as the `energy_delta` in kWh since last update. 
+- In case the event is a `stop` event, it will also report the **total** time (in seconds) and the **total** energy consumption of the cycle (in kWh). 
+
+Examples:
 
 `{ "name": "washer", "event": "start" }`
+
+`{ "name": "washer", "event": "pre_start", "time": 100, "energy": 0.003, "energy_delta": 0.002 }`
 
 `{ "name": "washer", "event": "running", "time": 4500, "energy": 0.05, "energy_delta": 0.009 }`
 
 `{ "name": "washer", "event": "stop", "time": 8800, "energy": 0.14 }`
-
 
 
 ## Contribute

--- a/readme.md
+++ b/readme.md
@@ -49,12 +49,12 @@ The node will trigger events based on the start and stop conditions with additio
 ### Output
 
 The output will be a JSON object with the appliance name and the event type. 
-In case the event is a `running` event, it will also report the **current** running time (in seconds) and the **current** energy consumption of the cycle (in kWh) since it started. 
+In case the event is a `running` event, it will also report the **current** running time (in seconds) and the **current** energy consumption of the cycle (in kWh) since it started, as well as the `energy_delta` in kWh since last update. 
 In case the event is a `stop` event, it will also report the **total** time (in seconds) and the **total** energy consumption of the cycle (in kWh). Examples:
 
 `{ "name": "washer", "event": "start" }`
 
-`{ "name": "washer", "event": "running", "time": 4500, "energy": 0.05 }`
+`{ "name": "washer", "event": "running", "time": 4500, "energy": 0.05, "energy_delta": 0.009 }`
 
 `{ "name": "washer", "event": "stop", "time": 8800, "energy": 0.14 }`
 

--- a/readme.md
+++ b/readme.md
@@ -48,9 +48,13 @@ The node will trigger events based on the start and stop conditions with additio
 
 ### Output
 
-The output will be a JSON object with the appliance name and the event type. In case the event is a stop event it will also report the total time (in seconds) and the energy consumption of the cycle (in kWh). Examples:
+The output will be a JSON object with the appliance name and the event type. 
+In case the event is a `running` event, it will also report the **current** running time (in seconds) and the **current** energy consumption of the cycle (in kWh) since it started. 
+In case the event is a `stop` event, it will also report the **total** time (in seconds) and the **total** energy consumption of the cycle (in kWh). Examples:
 
 `{ "name": "washer", "event": "start" }`
+
+`{ "name": "washer", "event": "running", "time": 4500, "energy": 0.05 }`
 
 `{ "name": "washer", "event": "stop", "time": 8800, "energy": 0.14 }`
 


### PR DESCRIPTION
This will cause the node to also output on `running` state with the current `time` and `energy` (in kWh) values mid-run.