### PR TITLE
`PreStart` should move to `PreStop` instead of `idle`

### DIFF
--- a/power-monitor/power-monitor.js
+++ b/power-monitor/power-monitor.js
@@ -105,7 +105,7 @@
                     if (node.count >= node.startafter) node.state = 2;
                     event_type = "pre_start";
                 } else {
-                    node.state = 0; 
+                    node.state = 4; 
                 }
             }
 


### PR DESCRIPTION
Otherwise, after `PreStart` there will never be a `stop` event.