### PR TITLE
Ability to configure energy delta decimals + idle status emission

### DIFF
--- a/power-monitor/power-monitor.html
+++ b/power-monitor/power-monitor.html
@@ -45,7 +45,7 @@
      <div class="form-row">
         <div style="display: inline;">
             <label for="node-input-emitidle" style="width: 120px;">Emit when idle</label>
-            <input type="checkbox" id="node-input-filter" style="display: inline-block; width: auto; vertical-align: top;">
+            <input type="checkbox" id="node-input-emitidle" style="display: inline-block; width: auto; vertical-align: top;">
         </div>
     </div>
 </script>

--- a/power-monitor/power-monitor.html
+++ b/power-monitor/power-monitor.html
@@ -38,6 +38,10 @@
         <label for="node-input-stopafter"><i class="fa fa-stop"></i> Stop after</label>
         <input type="number" min="1" id="node-input-stopafter" placeholder="1">
     </div>
+    <div class="form-row">
+        <label for="node-input-energydecimals">Round decimals</label>
+        <input type="number" min="0" id="node-input-energydecimals" placeholder="0">
+    </div>
 </script>
 
 <script type="text/x-red" data-help-name="power-monitor">
@@ -51,6 +55,7 @@
         The node assumes the input value is the average power consumption since the last input. You will have to feed the node regularly (every minute, for instance).
         It will trigger an event when the appliance starts or stops (think of a washer machine, for instance) based on a power threshold and time span.
         On every event it will also append the total time and energy consumption since it started.
+        Reported energy will be rounded to decimals configured.
     </p>
 
     <p>
@@ -71,7 +76,8 @@
             startthreshold: {value: 0},
             stopthreshold: {value: 0},
             startafter: {value: 1},
-            stopafter: {value: 1}
+            stopafter: {value: 1},
+            energydecimals: {value: 0}
         },
         color:"#FFCC66",
         inputs: 1,
@@ -91,6 +97,7 @@
             this.startafter = this.startafter || 1;
             this.stopthreshold = this.stopthreshold || 0;
             this.stopafter = this.stopafter || 1;
+            this.energydecimals = this.energydecimals || 0;
         }
     });
 </script>

--- a/power-monitor/power-monitor.html
+++ b/power-monitor/power-monitor.html
@@ -42,6 +42,12 @@
         <label for="node-input-energydecimals">Round decimals</label>
         <input type="number" min="0" id="node-input-energydecimals" placeholder="0">
     </div>
+     <div class="form-row">
+        <div style="display: inline;">
+            <label for="node-input-emitidle" style="width: 120px;">Emit when idle</label>
+            <input type="checkbox" id="node-input-filter" style="display: inline-block; width: auto; vertical-align: top;">
+        </div>
+    </div>
 </script>
 
 <script type="text/x-red" data-help-name="power-monitor">
@@ -56,6 +62,7 @@
         It will trigger an event when the appliance starts or stops (think of a washer machine, for instance) based on a power threshold and time span.
         On every event it will also append the total time and energy consumption since it started.
         Reported energy will be rounded to decimals configured.
+        You can also configure the node to emit idle status (in case the incoming power is zero).
     </p>
 
     <p>
@@ -77,7 +84,8 @@
             stopthreshold: {value: 0},
             startafter: {value: 1},
             stopafter: {value: 1},
-            energydecimals: {value: 0}
+            energydecimals: {value: 0},
+            emitidle: {value: false}
         },
         color:"#FFCC66",
         inputs: 1,
@@ -98,6 +106,7 @@
             this.stopthreshold = this.stopthreshold || 0;
             this.stopafter = this.stopafter || 1;
             this.energydecimals = this.energydecimals || 0;
+            this.emitidle = this.emitidle || false;
         }
     });
 </script>

--- a/power-monitor/power-monitor.html
+++ b/power-monitor/power-monitor.html
@@ -105,7 +105,7 @@
             this.startafter = this.startafter || 1;
             this.stopthreshold = this.stopthreshold || 0;
             this.stopafter = this.stopafter || 1;
-            this.energydecimals = this.energydecimals || 0;
+            this.energydecimals = this.energydecimals || 4;
             this.emitidle = this.emitidle || false;
         }
     });

--- a/power-monitor/power-monitor.js
+++ b/power-monitor/power-monitor.js
@@ -49,6 +49,7 @@
         this.stopthreshold = Number(config.stopthreshold || 0);
         this.stopafter = Number(config.stopafter || 1);
         this.energydecimals = Number(config.energydecimals || 0);
+        this.emitidle = Boolean(config.emitidle || false);
 
         // States:
         // 0: idle
@@ -153,13 +154,14 @@
                             "energy_delta": kwh(energy, node.energydecimals)
                     }}
                 );
-            } else {
+            } else if (node.emitidle) {
                 node.send(
                     { 
                         "payload": {
                             "name": node.name,
                             "power": power, // Sends power (watts) as received in previous node to next node. PR Update 12-Nov-21 Scott Wilson
-                            "event": "idle"
+                            "event": "idle",
+                            "energy_delta": 0
                     }}
                 );
             }

--- a/power-monitor/power-monitor.js
+++ b/power-monitor/power-monitor.js
@@ -144,7 +144,7 @@
                 node.send(
                     { "payload": {
                         "name": node.name,
-						                  "power": power, // Sends power (watts) as received in previous node to next node.
+			"power": power, // Sends power (watts) as received in previous node to next node.
                         "event": event_type,
                         "time": Math.round(time - node.start),
                         "energy": kwh(node.energy),
@@ -152,15 +152,15 @@
                     }}
                 );
             }
-			else {
+            else {
                 node.send(
                     { "payload": {
                         "name": node.name,
-						                  "power": power, // Sends power (watts) as received in previous node to next node. PR Update 12-Nov-21 Scott Wilson
+			"power": power, // Sends power (watts) as received in previous node to next node. PR Update 12-Nov-21 Scott Wilson
                         "event": "idle"    
                     }}
                 );			
-			}			
+            }			
 
             // Status
             if (0 == node.state) {

--- a/power-monitor/power-monitor.js
+++ b/power-monitor/power-monitor.js
@@ -144,6 +144,7 @@
                 node.send(
                     { "payload": {
                         "name": node.name,
+						                  "power": power, // Sends power (watts) as received in previous node to next node.
                         "event": event_type,
                         "time": Math.round(time - node.start),
                         "energy": kwh(node.energy),
@@ -151,6 +152,15 @@
                     }}
                 );
             }
+			else {
+                node.send(
+                    { "payload": {
+                        "name": node.name,
+						                  "power": power, // Sends power (watts) as received in previous node to next node. PR Update 12-Nov-21 Scott Wilson
+                        "event": "idle"    
+                    }}
+                );			
+			}			
 
             // Status
             if (0 == node.state) {


### PR DESCRIPTION
I'd like to add the ability to control decimals on the output energy delta, useful especially for low-energy devices. Then I also added an option to configure if the node should emit "idle" state events (most likely on incoming 0-power inputs).