### PR TITLE
Support for timed based events

### DIFF
--- a/power-monitor/power-monitor.html
+++ b/power-monitor/power-monitor.html
@@ -28,7 +28,12 @@
     </div>
     <div class="form-row">
         <label for="node-input-startafter"><i class="fa fa-play"></i> Start after</label>
-        <input type="number" min="1" id="node-input-startafter" placeholder="1">
+        <input type="number" min="1" id="node-input-startafter" placeholder="1" style="width: 40%;>
+        <label for="node-input-startperiodtype" margin-left: 10px; width: 50px;> Period</label>
+        <select id="node-input-startperiodtype" style="width:100px">
+           <option value="1">Readings</option>
+           <option value="2">Seconds</option>
+        </select>
     </div>
     <div class="form-row">
         <label for="node-input-stopthreshold"><i class="fa fa-thumbs-o-up"></i> Stop threshold</label>
@@ -36,7 +41,12 @@
     </div>
     <div class="form-row">
         <label for="node-input-stopafter"><i class="fa fa-stop"></i> Stop after</label>
-        <input type="number" min="1" id="node-input-stopafter" placeholder="1">
+        <input type="number" min="1" id="node-input-stopafter" placeholder="1" style="width: 40%;>
+        <label for="node-input-stopperiodtype" margin-left: 10px; width: 50px;> Period</label>
+        <select id="node-input-stopperiodtype" style="width:100px">
+           <option value="1">Readings</option>
+           <option value="2">Seconds</option>
+        </select>
     </div>
     <div class="form-row">
         <label for="node-input-energydecimals">Round decimals</label>
@@ -84,6 +94,8 @@
             stopthreshold: {value: 0},
             startafter: {value: 1},
             stopafter: {value: 1},
+            startperiodtype: {value: 1},
+            stopperiodtype: {value: 1},
             energydecimals: {value: 4},
             emitidle: {value: false}
         },
@@ -105,6 +117,8 @@
             this.startafter = this.startafter || 1;
             this.stopthreshold = this.stopthreshold || 0;
             this.stopafter = this.stopafter || 1;
+            this.startperiodtype = this.startperiodtype || 1;
+            this.stopperiodtype = this.stopperiodtype || 1;
             this.energydecimals = this.energydecimals || 4;
             this.emitidle = this.emitidle || false;
         }


### PR DESCRIPTION
Attempt to resole #10.

StartAfter and StopAfter can be ether readings count or seconds based.

Still requires a message to trigger the event, there is no internal timer. 
For example if you set it to StopAfter 60 seconds, and you get one event at 55 second, then another event at 90 seconds, it would stop at 90 seconds.
