### PR TITLE
Mbeynon preserve msg for output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-power-monitor",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "A Node-RED node to monitor home appliances based on their power consumption.",
     "homepage": "http://github.com/xoseperez/node-red-contrib-power-monitor",
     "bugs": "http://github.com/xoseperez/node-red-contrib-power-monitor/issues",

--- a/power-monitor/power-monitor.html
+++ b/power-monitor/power-monitor.html
@@ -48,6 +48,12 @@
             <input type="checkbox" id="node-input-emitidle" style="display: inline-block; width: auto; vertical-align: top;">
         </div>
     </div>
+    <div class="form-row">
+        <div style="display: inline;">
+            <label for="node-input-preserve-msg-props" style="width: 120px;">Preserve msg properties</label>
+            <input type="checkbox" id="node-input-preserve-msg-props" style="display: inline-block; width: auto; vertical-align: top;">
+        </div>
+    </div>
 </script>
 
 <script type="text/x-red" data-help-name="power-monitor">
@@ -75,6 +81,7 @@
         <li>Stop after - message count to wait before firing stop</li>
         <li>Round decimals - decimals for ouput of energy cosnuption</li>
         <li>You can configure the node to emit idle status (in case the incoming power is zero).</li>
+        <li>Preserve msg properties - use input msg for output, putting the output JSON object into the "payload" property.</li>
     </ul>
 
     <p>
@@ -99,7 +106,8 @@
             startafter: {value: 1},
             stopafter: {value: 1},
             energydecimals: {value: 4},
-            emitidle: {value: false}
+            emitidle: {value: false},
+            preservemsg: {value: false}
         },
         color:"#FFCC66",
         inputs: 1,
@@ -121,6 +129,7 @@
             this.stopafter = this.stopafter || 1;
             this.energydecimals = this.energydecimals || 4;
             this.emitidle = this.emitidle || false;
+            this.preservemsg = this.preservemsg || false;
         }
     });
 </script>

--- a/power-monitor/power-monitor.html
+++ b/power-monitor/power-monitor.html
@@ -50,8 +50,8 @@
     </div>
     <div class="form-row">
         <div style="display: inline;">
-            <label for="node-input-preserve-msg-props" style="width: 120px;">Preserve msg properties</label>
-            <input type="checkbox" id="node-input-preserve-msg-props" style="display: inline-block; width: auto; vertical-align: top;">
+            <label for="node-input-preservemsg" style="width: 120px;">Preserve msg properties</label>
+            <input type="checkbox" id="node-input-preservemsg" style="display: inline-block; width: auto; vertical-align: top;">
         </div>
     </div>
 </script>

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,7 @@ Latest version (1.0.0) is not backwards compatible with previous ones (0.X.X). T
 - `Start after`: Number of messages with readings over the threshold to trigger a start event.
 - `Stop threshold`: Value (in watts) to tell whether the device has finished, an ideal value would be 0 (0W if not running).
 - `Stop after`: Number of messages with readings below the threshold to trigger a stop event.
+- `Preserve msg properties`: Use the input msg for output, putting the output JSON object into the "payload" property.
 
 ### Input
 Two valid input options:


### PR DESCRIPTION
Hello,

I'm suggesting this change so that some flows I'm creating will work better.  I need to have properties other than payload in the msg input to the power-monitor node to be preserved.  Working around this is difficult, so I made these changes to collect feedback in the hope of getting this added.  The default setting of false for the new option is 100% compatible to prior behavior.

Thank you!
